### PR TITLE
Fixed Fault: Enum register causing failed deserialization

### DIFF
--- a/src/GladNet.Serializer.Protobuf/Strategies/ProtobufnetRegistry.cs
+++ b/src/GladNet.Serializer.Protobuf/Strategies/ProtobufnetRegistry.cs
@@ -14,6 +14,8 @@ namespace GladNet.Serializer.Protobuf
 	/// </summary>
 	public class ProtobufnetRegistry : ISerializerRegistry
 	{
+		//TODO: Make this class thread safe.
+
 		//Must be static to surive through multiple instances
 		private static Dictionary<Type, object> registeredTypes = new Dictionary<Type, object>();
 
@@ -27,6 +29,9 @@ namespace GladNet.Serializer.Protobuf
 
 			if (typeToRegister == null)
 				throw new ArgumentNullException(nameof(typeToRegister), $"Provided {typeToRegister} is a null arg.");
+
+			if (typeToRegister.IsEnum)
+				return true;
 
 			//if (RuntimeTypeModel.Default.IsDefined(typeToRegister))
 			//	return true;

--- a/tests/GladNet.Serializer.Protobuf.Tests/GladNet.Serializer.Protobuf.Tests.csproj
+++ b/tests/GladNet.Serializer.Protobuf.Tests/GladNet.Serializer.Protobuf.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ProtobufnetSerializerStrategyTests.cs" />
     <Compile Include="ProtobufnetDeserializerStrategyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegressionTests\EnumContractRegressionTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/GladNet.Serializer.Protobuf.Tests/RegressionTests/EnumContractRegressionTest.cs
+++ b/tests/GladNet.Serializer.Protobuf.Tests/RegressionTests/EnumContractRegressionTest.cs
@@ -1,0 +1,81 @@
+﻿using NUnit.Framework;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GladNet.Serializer.Protobuf.Tests
+{
+	[TestFixture]
+	public static class EnumContractRegressionTest
+	{
+		[Test]
+		public static void Test_Enum_Causes_Error_When_Registered_With_Contract()
+		{
+			//arrange
+			TestEnum val = TestEnum.Yep;
+			byte[] bytes = null;
+
+
+			//act
+			//Register it
+			new ProtobufnetRegistry().Register(typeof(TestEnum));
+
+			MemoryStream ms = new MemoryStream();
+
+			ProtoBuf.Serializer.Serialize(ms, val);
+			ms.Position = 0;
+
+			bytes = ms.ToArray();
+			ms.Position = 0;
+
+			TestEnum deserializedValue = ProtoBuf.Serializer.Deserialize<TestEnum>(ms);
+
+			Assert.AreEqual(val, deserializedValue);
+			Assert.IsTrue(ProtoBuf.Meta.RuntimeTypeModel.Default.CanSerialize(typeof(TestEnum)));
+		}
+
+		[Test]
+		public static void Test_Enum_Causes_Error_When_Registered_With_Contract_Test_With_Class()
+		{
+			//arrange
+			TestClass val = new TestClass();
+			byte[] bytes = null;
+
+
+			//act
+			//Register it
+			new ProtobufnetRegistry().Register(typeof(TestClass));
+
+			MemoryStream ms = new MemoryStream();
+
+			ProtoBuf.Serializer.Serialize(ms, val);
+			ms.Position = 0;
+
+			bytes = ms.ToArray();
+			ms.Position = 0;
+
+			TestClass deserializedValue = ProtoBuf.Serializer.Deserialize<TestClass>(ms);
+
+			Assert.AreEqual(val.TestEnumVal, deserializedValue.TestEnumVal);
+			Assert.IsTrue(ProtoBuf.Meta.RuntimeTypeModel.Default.CanSerialize(typeof(TestClass)));
+		}
+
+		[GladNetSerializationContract]
+		public class TestClass
+		{
+			[GladNetMember(1)]
+			public TestEnum TestEnumVal = TestEnum.Yep;
+		}
+
+		[GladNetSerializationContract]
+		public enum TestEnum : byte
+		{
+			Test,
+			Values,
+			Yep
+		}
+	}
+}


### PR DESCRIPTION
Do not register Enum types in the Runtime Typemodel.
